### PR TITLE
Add "chat" to the rules to match the code

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -4,6 +4,7 @@
     // By default, make all data private unless specified otherwise.
     ".read": false,
     ".write": false,
+    "chat" : {
     "room-metadata": {
       ".read": true,
       "$roomId": {
@@ -99,6 +100,7 @@
     "suspensions": {
       ".write": "(auth != null) && (root.child('moderators').hasChild(auth.uid))",
       ".read": "(auth != null) && (root.child('moderators').hasChild(auth.uid))"
+    }
     }
   }
 }


### PR DESCRIPTION
It appears that the "chat" level is missing.  I'm adding it.  This version works today (September 24, 2015)