### PR TITLE
Fixed race condition where _sessionId was null

### DIFF
--- a/src/js/firechat.js
+++ b/src/js/firechat.js
@@ -111,10 +111,8 @@
         }
       }, this);
 
-      // Generate a unique session id for the visit.
-      var sessionRef = this._userRef.child('sessions').push();
-      this._sessionId = sessionRef.key;
-      this._queuePresenceOperation(sessionRef, true, null);
+      // Queue up a presence operation to remove the session when presence is lost
+      this._queuePresenceOperation(this._sessionRef, true, null);
 
       // Register our username in the public user listing.
       var usernameRef = this._usersOnlineRef.child(this._userName.toLowerCase());
@@ -256,6 +254,9 @@
         self._userId = userId.toString();
         self._userName = userName.toString();
         self._userRef = self._firechatRef.child('users').child(self._userId);
+        self._sessionRef = self._userRef.child('sessions').push();
+        self._sessionId = self._sessionRef.key;
+
         self._loadUserMetadata(function() {
           root.setTimeout(function() {
             callback(self._user);


### PR DESCRIPTION
After deploying the latest version of Firechat, I noticed an error in the console due to the fact that `self._sessionId` is `null` on [this line](https://github.com/firebase/firechat/blob/eec01f2f314ed5a716e32dd141857e6556793444/src/js/firechat.js#L338). I am not sure exactly why this showed up now, but I think it is because `_sessionId` is set in `_setupDataEvents()` which is called with `onAuthStateChanged()` [here](https://github.com/firebase/firechat/blob/eec01f2f314ed5a716e32dd141857e6556793444/src/js/firechat.js#L262) and that method may not fire as soon in the `3.x.x` SDKs as `onAuth()` used to fire in the `2.x.x` SDKs. So, the `enterRoom()` call happens first (triggered by the Firechat UI code) and tries to use `_sessionId` before it is available. The solution is to just define `_sessionId` earlier. I have a hunch there are still race conditions, but this should be early enough that we won't hit it before the `enterRoom()` call happens.