### PR TITLE
fixes allowKick is not defined #91

### DIFF
--- a/src/js/firechat-ui.js
+++ b/src/js/firechat-ui.js
@@ -297,7 +297,8 @@
           self._chat.getRoom(messageVars.roomId, function(room) {
             // Show the context menu.
             $template = $(template({
-              id: $message.data('message-id')
+              id: $message.data('message-id'),
+              allowKick: false
             }));
             $template.css({
               left: event.clientX,


### PR DESCRIPTION
This is in reference to issue #91 

The following is the reason for the error "allowKick is not defined":

In the moderator options that are displayed in the context menu, allowKick is one of them and the template, "message-context-menu.html" references it. However, the allowKick parameter is not passed to the template under "showMessageContextMenu" in the function "_bindSuperuserUIEvents" in the file firechat-ui.js.

To solve this error, allowKick parameter is now passed to the template with a default value of **false**.